### PR TITLE
Add Linux-only line (it's systemd!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "mocha": "^2.4.5",
     "mockery": "^1.4.1"
   },
+  "os": [
+    "linux"
+  ],
   "jshintConfig": {
     "esversion": 6,
     "node": true,


### PR DESCRIPTION
This dependency WILL crash and burn on any non-Linux machine.  In order to be able to make it an optional dependency that doesn't get installed with an "npm install" on, say, Windows, package.json needs to indicate the OS as Linux.