### PR TITLE
Update journal_send.cc

### DIFF
--- a/src/journal_send.cc
+++ b/src/journal_send.cc
@@ -13,6 +13,10 @@
 #define TO_STR_H(x) "" #x
 #define TO_STR(x) TO_STR_H(x)
 
+// Instead of the locations being This file, Let users define their own 
+// CODE_FILE, CODE_LINE and CODE_FUNC, via stack trace (ex: npm callsite)
+#define SD_JOURNAL_SUPPRESS_LOCATION 1
+
 // Create an array of all Syslog priority numbers
 #define SYSLOG_PRIO_CNT 8
 const char *const syslogPrio[] = {

--- a/src/journal_send.cc
+++ b/src/journal_send.cc
@@ -5,6 +5,11 @@
 // Priority is a special case as it needs to be taken from the syslog.h
 // preprocessor definitions, which aren't available from JavaScript.
 
+
+// Instead of the locations being This file, Let users define their own 
+// CODE_FILE, CODE_LINE and CODE_FUNC, via stack trace (ex: npm callsite)
+#define SD_JOURNAL_SUPPRESS_LOCATION 1
+
 #include <nan.h>
 #include <systemd/sd-journal.h>
 #include <syslog.h>
@@ -12,10 +17,6 @@
 // Macros for int to string conversion
 #define TO_STR_H(x) "" #x
 #define TO_STR(x) TO_STR_H(x)
-
-// Instead of the locations being This file, Let users define their own 
-// CODE_FILE, CODE_LINE and CODE_FUNC, via stack trace (ex: npm callsite)
-#define SD_JOURNAL_SUPPRESS_LOCATION 1
 
 // Create an array of all Syslog priority numbers
 #define SYSLOG_PRIO_CNT 8


### PR DESCRIPTION
Make it possible to have more meaningful CODE_FILE, CODE_LINE and CODE_FUNC instead of them always pointing to journal_send.cc.

 CODE_FILE, CODE_LINE and CODE_FUNC can be populated from a stack trace, for example using the npm module callsite.