### PR TITLE
Allow specifying the syslog identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const log = require( 'systemd-journald' );
 const app = require( 'express' )();
 
 // This will be the displayed name in the journal
-process.title = "awesome-devide";
+log.identifier = "awesome-divide";
 
 app.get( '/:a/:b', ( req, res ) => {
   try {
@@ -50,14 +50,14 @@ app.get( '/:a/:b', ( req, res ) => {
     } );
 
     // Are you interested in the requests of a specific IP? Try:
-    // $ journalctl -t awesome-devide REMOTE_ADDR={IP}
+    // $ journalctl -t awesome-divide REMOTE_ADDR={IP}
     // As you can see, you have to enter the field names in capital letters.
 
   } catch( e ) {
 
     // The user screwed up! This will write the error message and stack trace to
     // the journal with priority 3. Checkout your journal:
-    // $ journalctl -t awesome-devide -p 3 -o json-pretty
+    // $ journalctl -t awesome-divide -p 3 -o json-pretty
     log.err( e );
 
     res.status( 400 ).end( e.message );

--- a/index.js
+++ b/index.js
@@ -64,9 +64,24 @@ function log( priority, message, fields ) {
 
 	}
 
-	if (module.exports.identifier) {
+	// Set the syslog identifier, if possible
+	if ( module.exports.identifier ) {
 
-		fields.SYSLOG_IDENTIFIER = module.exports.identifier;
+		// If the identifier is passed in via the fields object
+		// we want to use that one. So check if it is passed in.
+		var found = false;
+
+		for( var o in fields ) {
+			if (o.toUpperCase() == 'SYSLOG_IDENTIFIER') {
+				found = true;
+				break;
+			}
+		}
+
+		// If it wasn't passed in, use the global identifier
+		if ( !found ) {
+			fields.SYSLOG_IDENTIFIER = module.exports.identifier;
+		}
 
 	}
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,12 @@ function log( priority, message, fields ) {
 
 	}
 
+	if (module.exports.identifier) {
+
+		fields.SYSLOG_IDENTIFIER = module.exports.identifier;
+
+	}
+
 	var iovec = [];
 
 	// Add default fields

--- a/test/index.js
+++ b/test/index.js
@@ -203,4 +203,18 @@ describe( "node-systemd-journald", function() {
 
 	} );
 
+	it( "should set the syslog identifier", function( done ) {
+
+		log.identifier = 'test-identifier';
+		log.debug( 'Test' );
+
+		try {
+			assert.strictEqual( journal_send.getField( 'SYSLOG_IDENTIFIER' ), 'test-identifier' );
+			done();
+		} catch( e ) {
+			done( e );
+		}
+
+	} );
+
 } );

--- a/test/index.js
+++ b/test/index.js
@@ -217,4 +217,20 @@ describe( "node-systemd-journald", function() {
 
 	} );
 
+	it( "should prefer the identifier set in the options to the global identifier", function( done ) {
+
+		log.identifier = 'test-identifier';
+		log.debug( 'Test', {
+			syslog_identifier: 'local-identifier'
+		} );
+
+		try {
+			assert.strictEqual( journal_send.getField( 'SYSLOG_IDENTIFIER' ), 'local-identifier' );
+			done();
+		} catch( e ) {
+			done( e );
+		}
+
+	} );
+
 } );


### PR DESCRIPTION
Set the syslog identifier by setting `log.identifier` to the preferred identifier.

This replaces the reliance on `process.title`, which has limitations, according to the [node docs][1].

[1]: https://nodejs.org/api/process.html#process_process_title

Addresses #7.