### PR TITLE
TS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "journald"
   ],
   "author": "Jue <me@jue.yt>",
+  "contributors": ["Mikel Pérez <io@mikelpr.com>"],
   "license": "MIT",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/jue89/node-systemd-journald.git"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,42 @@
+declare module "systemd-journald" {
+  // https://man7.org/linux/man-pages/man7/systemd.journal-fields.7.html
+  export type JournalFields = {
+    message_id?: string,
+    code_file?: string,
+    code_line?: string,
+    code_func?: string,
+    errno?: string,
+    invocation_id?: string,
+    user_invocation_id?: string,
+    syslog_facility?: string,
+    syslog_identifier?: string,
+    syslog_pid?: string,
+    syslog_timestamp?: string,
+    syslog_raw?: string,
+    documentation?: string,
+    tid?: string,
+    unit?: string,
+    user_unit?: string
+  }
+
+  export default class systemd_journald {
+    constructor(defaultFields: JournalFields);
+
+    alert(message: string, fields?: JournalFields): void;
+    crit(message: string, fields?: JournalFields): void;
+    debug(message: string, fields?: JournalFields): void;
+    emerg(message: string, fields?: JournalFields): void;
+    err(message: string, fields?: JournalFields): void;
+    info(message: string, fields?: JournalFields): void;
+    notice(message: string, fields?: JournalFields): void;
+    warning(message: string, fields?: JournalFields): void;
+    static alert(message: string, fields?: JournalFields): void;
+    static crit(message: string, fields?: JournalFields): void;
+    static debug(message: string, fields?: JournalFields): void;
+    static emerg(message: string, fields?: JournalFields): void;
+    static err(message: string, fields?: JournalFields): void;
+    static info(message: string, fields?: JournalFields): void;
+    static notice(message: string, fields?: JournalFields): void;
+    static warning(message: string, fields?: JournalFields): void;
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,23 +1,24 @@
-declare module "systemd-journald" {
+declare module 'systemd-journald' {
   // https://man7.org/linux/man-pages/man7/systemd.journal-fields.7.html
-  export type JournalFields = {
-    message_id?: string,
-    code_file?: string,
-    code_line?: string,
-    code_func?: string,
-    errno?: string,
-    invocation_id?: string,
-    user_invocation_id?: string,
-    syslog_facility?: string,
-    syslog_identifier?: string,
-    syslog_pid?: string,
-    syslog_timestamp?: string,
-    syslog_raw?: string,
-    documentation?: string,
-    tid?: string,
-    unit?: string,
-    user_unit?: string
-  }
+  export type JournalFields = Partial<{
+    message_id: string,
+    code_file: string,
+    code_line: string,
+    code_func: string,
+    errno: string,
+    invocation_id: string,
+    user_invocation_id: string,
+    syslog_facility: string,
+    syslog_identifier: string,
+    syslog_pid: string,
+    syslog_timestamp: string,
+    syslog_raw: string,
+    documentation: string,
+    tid: string,
+    unit: string,
+    user_unit: string,
+    [custom_field: string]: string
+  }>
 
   export default class systemd_journald {
     constructor(defaultFields: JournalFields);


### PR DESCRIPTION
added the allowed fields as listed in https://man7.org/linux/man-pages/man7/systemd.journal-fields.7.html minus the message and priority ones which are handled already in log.js